### PR TITLE
add an output component to support output both string and image in a ZIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,5 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 /temp/
+src/.DS_Store
+.DS_Store

--- a/src/comfy_pack/utils.py
+++ b/src/comfy_pack/utils.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 CPACK_OUTPUT_NODES = {
     "CPackOutputFile",
     "CPackOutputImage",
+    "CPackOutputZip"
 }
 
 CPACK_PATH_INPUT_NODES = {


### PR DESCRIPTION
Hi, I added an output component that accepts an image and a string as input; it will output a packed zip file containing both the image and a text file with the string for further API purposes. I already tested and it works well.
![api success screenshot](https://github.com/user-attachments/assets/adcb1859-9ace-4899-9798-ca68ce52a76b)
