### PR TITLE
fix packaging for huggingface

### DIFF
--- a/src/comfy_pack/model_helper.py
+++ b/src/comfy_pack/model_helper.py
@@ -1,7 +1,8 @@
-from .const import MODEL_SOURCE_CACHE_FILE
 import asyncio
 import json
 import re
+
+from .const import MODEL_SOURCE_CACHE_FILE
 
 # MODEL_NAME = r"[a-zA-Z0-9-._]+"
 # COMMIT = r"[a-f0-9]+"
@@ -14,9 +15,8 @@ PATH_PATTERN = re.compile(
 
 
 async def _lookup_huggingface_model(model_sha: str) -> dict:
-    from duckduckgo_search import DDGS
     import aiohttp
-
+    from duckduckgo_search import DDGS
     query = f"site:huggingface.co blob {model_sha}"
 
     try:
@@ -25,7 +25,7 @@ async def _lookup_huggingface_model(model_sha: str) -> dict:
 
             async with aiohttp.ClientSession(trust_env=True) as session:
                 for result in search_results:
-                    url = result['link']
+                    url = result['href']
                     if "blob" not in url:
                         continue
 
@@ -38,11 +38,9 @@ async def _lookup_huggingface_model(model_sha: str) -> dict:
                                 repo, commit = commit_match.groups()
                                 if path_match := PATH_PATTERN.search(text):
                                     path = path_match.group(1)
-                                    download_url = f"https://huggingface.co/{repo}/resolve/{commit}/{path}?download=true"
-                                    url = f"https://huggingface.co/{repo}/blob/{commit}/{path}"
                                     info = {
-                                        "download_url": download_url,
-                                        "url": url,
+                                        "download_url": path,
+                                        "url": path,
                                         "repo": repo,
                                         "commit": commit,
                                         "path": path,


### PR DESCRIPTION
Hello,

the packaging for huggingface models did not work for me so I debugged a bit. With the code below it works again.

Before the snapshot of the models would look like this:

```json
  "models": [
    {
      "filename": "models/checkpoints/v1-5-pruned-emaonly.ckpt",
      "size": 4265380512,
      "atime": 1747745096.7829416,
      "ctime": 1730925720.585791,
      "disabled": false,
      "sha256": "cc6cb27103417325ff94f52b7a5d2dde45a7515b25c255d8e396c90014281516",
      "source": {
        "download_url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5/resolve/f03de327dd89b501a01da37fc5240cf4fdba85a1/https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.ckpt?download=true",
        "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5/blob/f03de327dd89b501a01da37fc5240cf4fdba85a1/https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.ckpt",
        "repo": "stable-diffusion-v1-5/stable-diffusion-v1-5",
        "commit": "f03de327dd89b501a01da37fc5240cf4fdba85a1",
        "path": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.ckpt",
        "source": "huggingface"
      }
    }
  ],
```

The download_url ([download_url](https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5/resolve/f03de327dd89b501a01da37fc5240cf4fdba85a1/https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.ckpt?download=true)) could not be resolved.

after the fix it looks like this:

```json
  "models": [
    {
      "filename": "models/checkpoints/v1-5-pruned-emaonly.ckpt",
      "size": 4265380512,
      "atime": 1747745096.7829416,
      "ctime": 1730925720.585791,
      "disabled": false,
      "sha256": "cc6cb27103417325ff94f52b7a5d2dde45a7515b25c255d8e396c90014281516",
      "source": {
        "download_url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.ckpt",
        "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.ckpt",
        "repo": "stable-diffusion-v1-5/stable-diffusion-v1-5",
        "commit": "f03de327dd89b501a01da37fc5240cf4fdba85a1",
        "path": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.ckpt",
        "source": "huggingface"
      }
    }
  ],
```

and curl can download it again.

it also seems duckduckgo search results use the "href" key not the "link" key.